### PR TITLE
Add `Activate on launch` features to SekiroTool

### DIFF
--- a/SekiroTool/Enums/State.cs
+++ b/SekiroTool/Enums/State.cs
@@ -9,6 +9,6 @@ public enum State
     NotLoaded,
     GameStart,
     AppClosing,
-    AppStarting,
+    AppStart,
     EventTabActivated,
 }

--- a/SekiroTool/MainWindow.xaml.cs
+++ b/SekiroTool/MainWindow.xaml.cs
@@ -79,7 +79,11 @@ public partial class MainWindow : Window
         ItemViewModel itemViewModel = new ItemViewModel(itemService, _stateService);
         EventViewModel eventViewModel =
             new EventViewModel(eventService, _stateService, debugDrawService, itemService, _hotkeyManager);
-        SettingsViewModel settingsViewModel = new SettingsViewModel(settingsService, _stateService, _hotkeyManager);
+        var activateOnLaunchManager = new ActivateOnLaunchManager();
+        ActivateOnLaunchViewModel activateOnLaunchViewModel = new ActivateOnLaunchViewModel(playerViewModel,
+            targetViewModel, eventViewModel, travelViewModel, activateOnLaunchManager, _stateService);
+        SettingsViewModel settingsViewModel = new SettingsViewModel(settingsService, _stateService, _hotkeyManager,
+            activateOnLaunchViewModel);
 
         var playerTab = new PlayerTab(playerViewModel);
         var travelTab = new TravelTab(travelViewModel);
@@ -102,6 +106,8 @@ public partial class MainWindow : Window
         MainTabControl.SelectionChanged += MainTabControl_SelectionChanged;
 
         settingsViewModel.ApplyStartUpOptions();
+
+        _stateService.Publish(State.AppStart);
 
         Closing += MainWindow_Closing;
 

--- a/SekiroTool/Utilities/ActivateOnLaunchManager.cs
+++ b/SekiroTool/Utilities/ActivateOnLaunchManager.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace SekiroTool.Utilities;
+
+public class ActivateOnLaunchManager
+{
+    private readonly Dictionary<string, string> _values = new();
+
+    public ActivateOnLaunchManager()
+    {
+        Load();
+    }
+
+    public bool GetBool(string actionId)
+    {
+        return _values.TryGetValue(actionId, out var v) && bool.TryParse(v, out var b) && b;
+    }
+
+    public void SetBool(string actionId, bool value)
+    {
+        _values[actionId] = value.ToString();
+        Save();
+    }
+
+    public int GetInt(string actionId, int defaultValue = 0)
+    {
+        return _values.TryGetValue(actionId, out var v) && int.TryParse(v, out var i) ? i : defaultValue;
+    }
+
+    public void SetInt(string actionId, int value)
+    {
+        _values[actionId] = value.ToString();
+        Save();
+    }
+
+    public double GetDouble(string actionId, double defaultValue = 0)
+    {
+        return _values.TryGetValue(actionId, out var v) &&
+               double.TryParse(v, NumberStyles.Float, CultureInfo.InvariantCulture, out var d)
+            ? d
+            : defaultValue;
+    }
+
+    public void SetDouble(string actionId, double value)
+    {
+        _values[actionId] = value.ToString(CultureInfo.InvariantCulture);
+        Save();
+    }
+
+    public void Save()
+    {
+        try
+        {
+            SettingsManager.Default.ActivateOnLaunchActionIds = string.Join(",", _values.Select(kv => $"{kv.Key}:{kv.Value}"));
+            SettingsManager.Default.Save();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($@"Error saving activate on launch settings: {ex.Message}");
+        }
+    }
+
+    public void Load()
+    {
+        try
+        {
+            _values.Clear();
+            var raw = SettingsManager.Default.ActivateOnLaunchActionIds;
+            if (string.IsNullOrEmpty(raw)) return;
+
+            foreach (var token in raw.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var separatorIndex = token.IndexOf(':');
+                if (separatorIndex <= 0) continue;
+                _values[token.Substring(0, separatorIndex)] = token.Substring(separatorIndex + 1);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($@"Error loading activate on launch settings: {ex.Message}");
+        }
+    }
+}

--- a/SekiroTool/Utilities/SettingsManager.cs
+++ b/SekiroTool/Utilities/SettingsManager.cs
@@ -11,6 +11,8 @@ public class SettingsManager
     public static SettingsManager Default => _default ??= Load();
     
     public string HotkeyActionIds { get; set; } = "";
+    public bool ActivateOnLaunchEnabled { get; set; }
+    public string ActivateOnLaunchActionIds { get; set; } = "";
     public bool EnableHotkeys { get; set; }
     public bool NoLogo { get; set; }
     public bool AlwaysOnTop { get; set; }

--- a/SekiroTool/ViewModels/ActivateOnLaunchViewModel.cs
+++ b/SekiroTool/ViewModels/ActivateOnLaunchViewModel.cs
@@ -355,8 +355,12 @@ public class ActivateOnLaunchViewModel : BaseViewModel
             _playerViewModel.IsDamageMultiplierEnabled = true;
         }
 
-        // Target
-        if (IsEnableTargetOptionsChecked) _targetViewModel.IsTargetOptionsEnabled = true;
+        // New Game Cycle
+        // Must be primed here (State.AppStart) rather than on State.GameStart: PlayerViewModel's own
+        // OnGameStart handler reads IsAutoSetNewGameSevenEnabled on that same event, and subscribes to
+        // it before ActivateOnLaunchViewModel does, so setting the flag on GameStart would always run
+        // one publish too late to be read.
+        if (IsAutoSetNewGame7Checked) _playerViewModel.IsAutoSetNewGameSevenEnabled = true;
     }
 
     private void OnGameAttached()
@@ -369,13 +373,14 @@ public class ActivateOnLaunchViewModel : BaseViewModel
     private void OnGameLoaded()
     {
         if (!IsEnabled) return;
+
+        // Target
+        if (IsEnableTargetOptionsChecked) _targetViewModel.IsTargetOptionsEnabled = true;
     }
 
     private async void OnNewGameStart()
     {
         if (!IsEnabled) return;
-
-        if (IsAutoSetNewGame7Checked) _playerViewModel.IsAutoSetNewGameSevenEnabled = true;
 
         if (IsDemonBellOnChecked) _eventViewModel.SetDemonBellCommand.Execute(true);
         if (IsDemonBellOffChecked) _eventViewModel.SetDemonBellCommand.Execute(false);

--- a/SekiroTool/ViewModels/ActivateOnLaunchViewModel.cs
+++ b/SekiroTool/ViewModels/ActivateOnLaunchViewModel.cs
@@ -1,0 +1,392 @@
+using System.Threading.Tasks;
+using SekiroTool.Enums;
+using SekiroTool.Interfaces;
+using SekiroTool.Utilities;
+
+namespace SekiroTool.ViewModels;
+
+public class ActivateOnLaunchViewModel : BaseViewModel
+{
+    private readonly PlayerViewModel _playerViewModel;
+    private readonly TargetViewModel _targetViewModel;
+    private readonly EventViewModel _eventViewModel;
+    private readonly TravelViewModel _travelViewModel;
+    private readonly ActivateOnLaunchManager _aol;
+
+    public ActivateOnLaunchViewModel(PlayerViewModel playerViewModel, TargetViewModel targetViewModel,
+        EventViewModel eventViewModel, TravelViewModel travelViewModel,
+        ActivateOnLaunchManager activateOnLaunchManager, IStateService stateService)
+    {
+        _playerViewModel = playerViewModel;
+        _targetViewModel = targetViewModel;
+        _eventViewModel = eventViewModel;
+        _travelViewModel = travelViewModel;
+        _aol = activateOnLaunchManager;
+
+        RegisterActions();
+
+        stateService.Subscribe(State.AppStart, OnAppStart);
+        stateService.Subscribe(State.Attached, OnGameAttached);
+        stateService.Subscribe(State.Loaded, OnGameLoaded);
+        stateService.Subscribe(State.GameStart, OnNewGameStart);
+    }
+
+    #region Properties
+
+    // Master toggle
+    private bool _isEnabled = SettingsManager.Default.ActivateOnLaunchEnabled;
+
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        set
+        {
+            if (!SetProperty(ref _isEnabled, value)) return;
+            SettingsManager.Default.ActivateOnLaunchEnabled = value;
+            SettingsManager.Default.Save();
+        }
+    }
+
+    // Helper macros
+    private bool Get(string id) => _aol.GetBool(id);
+    private void Set(string id, bool value) => _aol.SetBool(id, value);
+
+    // Player
+    private bool _isInfiniteConfettiChecked;
+
+    public bool IsInfiniteConfettiChecked
+    {
+        get => _isInfiniteConfettiChecked;
+        set
+        {
+            if (SetProperty(ref _isInfiniteConfettiChecked, value)) Set(nameof(IsInfiniteConfettiChecked), value);
+        }
+    }
+
+    private bool _isInfiniteGachiinChecked;
+
+    public bool IsInfiniteGachiinChecked
+    {
+        get => _isInfiniteGachiinChecked;
+        set
+        {
+            if (SetProperty(ref _isInfiniteGachiinChecked, value)) Set(nameof(IsInfiniteGachiinChecked), value);
+        }
+    }
+
+    private bool _isOneShotHealthChecked;
+
+    public bool IsOneShotHealthChecked
+    {
+        get => _isOneShotHealthChecked;
+        set
+        {
+            if (SetProperty(ref _isOneShotHealthChecked, value)) Set(nameof(IsOneShotHealthChecked), value);
+        }
+    }
+
+    private bool _isOneShotPostureChecked;
+
+    public bool IsOneShotPostureChecked
+    {
+        get => _isOneShotPostureChecked;
+        set
+        {
+            if (SetProperty(ref _isOneShotPostureChecked, value)) Set(nameof(IsOneShotPostureChecked), value);
+        }
+    }
+
+    private bool _isNoGoodsConsumeChecked;
+
+    public bool IsNoGoodsConsumeChecked
+    {
+        get => _isNoGoodsConsumeChecked;
+        set
+        {
+            if (SetProperty(ref _isNoGoodsConsumeChecked, value)) Set(nameof(IsNoGoodsConsumeChecked), value);
+        }
+    }
+
+    private bool _isNoEmblemConsumeChecked;
+
+    public bool IsNoEmblemConsumeChecked
+    {
+        get => _isNoEmblemConsumeChecked;
+        set
+        {
+            if (SetProperty(ref _isNoEmblemConsumeChecked, value)) Set(nameof(IsNoEmblemConsumeChecked), value);
+        }
+    }
+
+    private bool _isInfiniteRevivalChecked;
+
+    public bool IsInfiniteRevivalChecked
+    {
+        get => _isInfiniteRevivalChecked;
+        set
+        {
+            if (SetProperty(ref _isInfiniteRevivalChecked, value)) Set(nameof(IsInfiniteRevivalChecked), value);
+        }
+    }
+
+    private bool _isPlayerHideChecked;
+
+    public bool IsPlayerHideChecked
+    {
+        get => _isPlayerHideChecked;
+        set
+        {
+            if (SetProperty(ref _isPlayerHideChecked, value)) Set(nameof(IsPlayerHideChecked), value);
+        }
+    }
+
+    private bool _isPlayerSilentChecked;
+
+    public bool IsPlayerSilentChecked
+    {
+        get => _isPlayerSilentChecked;
+        set
+        {
+            if (SetProperty(ref _isPlayerSilentChecked, value)) Set(nameof(IsPlayerSilentChecked), value);
+        }
+    }
+
+    private bool _isInfinitePoiseChecked;
+
+    public bool IsInfinitePoiseChecked
+    {
+        get => _isInfinitePoiseChecked;
+        set
+        {
+            if (SetProperty(ref _isInfinitePoiseChecked, value)) Set(nameof(IsInfinitePoiseChecked), value);
+        }
+    }
+
+    private bool _isNoDeathChecked;
+
+    public bool IsNoDeathChecked
+    {
+        get => _isNoDeathChecked;
+        set
+        {
+            if (SetProperty(ref _isNoDeathChecked, value)) Set(nameof(IsNoDeathChecked), value);
+        }
+    }
+
+    private bool _isNoDeathExKillboxChecked;
+
+    public bool IsNoDeathExKillboxChecked
+    {
+        get => _isNoDeathExKillboxChecked;
+        set
+        {
+            if (SetProperty(ref _isNoDeathExKillboxChecked, value)) Set(nameof(IsNoDeathExKillboxChecked), value);
+        }
+    }
+
+    private bool _isNoDamageChecked;
+
+    public bool IsNoDamageChecked
+    {
+        get => _isNoDamageChecked;
+        set
+        {
+            if (SetProperty(ref _isNoDamageChecked, value)) Set(nameof(IsNoDamageChecked), value);
+        }
+    }
+
+    private bool _isToggleDamageMultiplierChecked;
+
+    public bool IsToggleDamageMultiplierChecked
+    {
+        get => _isToggleDamageMultiplierChecked;
+        set
+        {
+            if (SetProperty(ref _isToggleDamageMultiplierChecked, value))
+                Set(nameof(IsToggleDamageMultiplierChecked), value);
+        }
+    }
+
+    private double _damageMultiplierValue;
+
+    public double DamageMultiplierValue
+    {
+        get => _damageMultiplierValue;
+        set
+        {
+            if (SetProperty(ref _damageMultiplierValue, value))
+                _aol.SetDouble(nameof(DamageMultiplierValue), value);
+        }
+    }
+
+    // Target
+    private bool _isEnableTargetOptionsChecked;
+
+    public bool IsEnableTargetOptionsChecked
+    {
+        get => _isEnableTargetOptionsChecked;
+        set
+        {
+            if (SetProperty(ref _isEnableTargetOptionsChecked, value))
+                Set(nameof(IsEnableTargetOptionsChecked), value);
+        }
+    }
+
+    // Travel
+    private bool _isUnlockIdolsChecked;
+
+    public bool IsUnlockIdolsChecked
+    {
+        get => _isUnlockIdolsChecked;
+        set
+        {
+            if (SetProperty(ref _isUnlockIdolsChecked, value)) Set(nameof(IsUnlockIdolsChecked), value);
+        }
+    }
+
+    // New Game Cycle
+    private bool _isAutoSetNewGame7Checked;
+
+    public bool IsAutoSetNewGame7Checked
+    {
+        get => _isAutoSetNewGame7Checked;
+        set
+        {
+            if (SetProperty(ref _isAutoSetNewGame7Checked, value)) Set(nameof(IsAutoSetNewGame7Checked), value);
+        }
+    }
+
+    private bool _isDemonBellOnChecked;
+
+    public bool IsDemonBellOnChecked
+    {
+        get => _isDemonBellOnChecked;
+        set
+        {
+            if (SetProperty(ref _isDemonBellOnChecked, value)) Set(nameof(IsDemonBellOnChecked), value);
+        }
+    }
+
+    private bool _isDemonBellOffChecked;
+
+    public bool IsDemonBellOffChecked
+    {
+        get => _isDemonBellOffChecked;
+        set
+        {
+            if (SetProperty(ref _isDemonBellOffChecked, value)) Set(nameof(IsDemonBellOffChecked), value);
+        }
+    }
+
+    private bool _isNoKurosCharmOnChecked;
+
+    public bool IsNoKurosCharmOnChecked
+    {
+        get => _isNoKurosCharmOnChecked;
+        set
+        {
+            if (SetProperty(ref _isNoKurosCharmOnChecked, value)) Set(nameof(IsNoKurosCharmOnChecked), value);
+        }
+    }
+
+    private bool _isNoKurosCharmOffChecked;
+
+    public bool IsNoKurosCharmOffChecked
+    {
+        get => _isNoKurosCharmOffChecked;
+        set
+        {
+            if (SetProperty(ref _isNoKurosCharmOffChecked, value)) Set(nameof(IsNoKurosCharmOffChecked), value);
+        }
+    }
+
+    #endregion
+
+    private void RegisterActions()
+    {
+        _isInfiniteConfettiChecked = Get(nameof(IsInfiniteConfettiChecked));
+        _isInfiniteGachiinChecked = Get(nameof(IsInfiniteGachiinChecked));
+        _isOneShotHealthChecked = Get(nameof(IsOneShotHealthChecked));
+        _isOneShotPostureChecked = Get(nameof(IsOneShotPostureChecked));
+        _isNoGoodsConsumeChecked = Get(nameof(IsNoGoodsConsumeChecked));
+        _isNoEmblemConsumeChecked = Get(nameof(IsNoEmblemConsumeChecked));
+        _isInfiniteRevivalChecked = Get(nameof(IsInfiniteRevivalChecked));
+        _isPlayerHideChecked = Get(nameof(IsPlayerHideChecked));
+        _isPlayerSilentChecked = Get(nameof(IsPlayerSilentChecked));
+        _isInfinitePoiseChecked = Get(nameof(IsInfinitePoiseChecked));
+        _isNoDeathChecked = Get(nameof(IsNoDeathChecked));
+        _isNoDeathExKillboxChecked = Get(nameof(IsNoDeathExKillboxChecked));
+        _isNoDamageChecked = Get(nameof(IsNoDamageChecked));
+        _isToggleDamageMultiplierChecked = Get(nameof(IsToggleDamageMultiplierChecked));
+        _damageMultiplierValue = _aol.GetDouble(nameof(DamageMultiplierValue), defaultValue: 1.0);
+
+        _isEnableTargetOptionsChecked = Get(nameof(IsEnableTargetOptionsChecked));
+
+        _isUnlockIdolsChecked = Get(nameof(IsUnlockIdolsChecked));
+
+        _isAutoSetNewGame7Checked = Get(nameof(IsAutoSetNewGame7Checked));
+        _isDemonBellOnChecked = Get(nameof(IsDemonBellOnChecked));
+        _isDemonBellOffChecked = Get(nameof(IsDemonBellOffChecked));
+        _isNoKurosCharmOnChecked = Get(nameof(IsNoKurosCharmOnChecked));
+        _isNoKurosCharmOffChecked = Get(nameof(IsNoKurosCharmOffChecked));
+    }
+
+    private void OnAppStart()
+    {
+        if (!IsEnabled) return;
+
+        // Player
+        if (IsInfiniteConfettiChecked) _playerViewModel.IsConfettiFlagEnabled = true;
+        if (IsInfiniteGachiinChecked) _playerViewModel.IsGachiinFlagEnabled = true;
+        if (IsOneShotHealthChecked) _playerViewModel.IsOneShotEnabled = true;
+        if (IsOneShotPostureChecked) _playerViewModel.IsOneShotPostureEnabled = true;
+        if (IsNoGoodsConsumeChecked) _playerViewModel.IsNoGoodsConsumeEnabled = true;
+        if (IsNoEmblemConsumeChecked) _playerViewModel.IsNoEmblemConsumeEnabled = true;
+        if (IsInfiniteRevivalChecked) _playerViewModel.IsNoRevivalConsumeEnabled = true;
+        if (IsPlayerHideChecked) _playerViewModel.IsPlayerHideEnabled = true;
+        if (IsPlayerSilentChecked) _playerViewModel.IsPlayerSilentEnabled = true;
+        if (IsInfinitePoiseChecked) _playerViewModel.IsInfinitePoiseEnabled = true;
+        if (IsNoDeathChecked) _playerViewModel.IsNoDeathEnabled = true;
+        if (IsNoDeathExKillboxChecked) _playerViewModel.IsNoDeathEnabledWithoutKillbox = true;
+        if (IsNoDamageChecked) _playerViewModel.IsNoDamageEnabled = true;
+        if (IsToggleDamageMultiplierChecked)
+        {
+            _playerViewModel.DamageMultiplier = DamageMultiplierValue;
+            _playerViewModel.IsDamageMultiplierEnabled = true;
+        }
+
+        // Target
+        if (IsEnableTargetOptionsChecked) _targetViewModel.IsTargetOptionsEnabled = true;
+    }
+
+    private void OnGameAttached()
+    {
+        // No attach-gated Activate On Launch options for Sekiro yet (e.g. TarnishedTool's launch FPS);
+        // kept for lifecycle parity with the other tools.
+        if (!IsEnabled) return;
+    }
+
+    private void OnGameLoaded()
+    {
+        if (!IsEnabled) return;
+    }
+
+    private async void OnNewGameStart()
+    {
+        if (!IsEnabled) return;
+
+        if (IsAutoSetNewGame7Checked) _playerViewModel.IsAutoSetNewGameSevenEnabled = true;
+
+        if (IsDemonBellOnChecked) _eventViewModel.SetDemonBellCommand.Execute(true);
+        if (IsDemonBellOffChecked) _eventViewModel.SetDemonBellCommand.Execute(false);
+        if (IsNoKurosCharmOnChecked) _eventViewModel.SetNoKurosCharmCommand.Execute(true);
+        if (IsNoKurosCharmOffChecked) _eventViewModel.SetNoKurosCharmCommand.Execute(false);
+
+        // Travel
+        if (IsUnlockIdolsChecked && _travelViewModel.UnlockIdolsCommand.CanExecute(null))
+        {
+            await Task.Delay(1500);
+            _travelViewModel.UnlockIdolsCommand.Execute(null);
+        }
+    }
+}

--- a/SekiroTool/ViewModels/PlayerViewModel.cs
+++ b/SekiroTool/ViewModels/PlayerViewModel.cs
@@ -594,7 +594,7 @@ public class PlayerViewModel : BaseViewModel
 
         if (IsNoGoodsConsumeEnabled) _playerService.TogglePlayerNoGoodsConsume(true);
 
-        if (IsNoEmblemConsumeEnabled) _playerService.TogglePlayerNoGoodsConsume(true);
+        if (IsNoEmblemConsumeEnabled) _playerService.TogglePlayerNoEmblemsConsume(true);
 
         if (IsNoRevivalConsumeEnabled) _playerService.TogglePlayerNoRevivalConsume(true);
 

--- a/SekiroTool/ViewModels/SettingsViewModel.cs
+++ b/SekiroTool/ViewModels/SettingsViewModel.cs
@@ -7,6 +7,7 @@ using SekiroTool.Core;
 using SekiroTool.Enums;
 using SekiroTool.Interfaces;
 using SekiroTool.Utilities;
+using SekiroTool.Views.Windows;
 using Key = H.Hooks.Key;
 using KeyboardEventArgs = H.Hooks.KeyboardEventArgs;
 
@@ -16,6 +17,8 @@ public class SettingsViewModel : BaseViewModel
 {
     private readonly ISettingsService _settingsService;
     private readonly HotkeyManager _hotkeyManager;
+    private readonly ActivateOnLaunchViewModel _activateOnLaunchViewModel;
+    private ActivateOnLaunchWindow _activateOnLaunchWindow;
 
     private readonly Dictionary<string, HotkeyBindingViewModel> _hotkeyLookup;
 
@@ -31,10 +34,11 @@ public class SettingsViewModel : BaseViewModel
     public ObservableCollection<HotkeyBindingViewModel> BossSkipHotkeys { get; }
 
     public SettingsViewModel(ISettingsService settingsService, IStateService stateService,
-        HotkeyManager hotkeyManager)
+        HotkeyManager hotkeyManager, ActivateOnLaunchViewModel activateOnLaunchViewModel)
     {
         _settingsService = settingsService;
         _hotkeyManager = hotkeyManager;
+        _activateOnLaunchViewModel = activateOnLaunchViewModel;
 
         stateService.Subscribe(State.Attached, OnGameAttached);
         stateService.Subscribe(State.EarlyAttached, OnGameEarlyAttached);
@@ -148,15 +152,17 @@ public class SettingsViewModel : BaseViewModel
             .Concat((EventHotkeys))
             .ToDictionary(h => h.ActionId);
         LoadHotkeyDisplays();
-        
+
         ClearHotkeysCommand = new DelegateCommand(ClearHotkeys);
+        OpenActivateOnLaunchCommand = new DelegateCommand(OpenActivateOnLaunch);
     }
 
-  
+
 
     #region Commands
 
     public ICommand ClearHotkeysCommand { get; set; }
+    public ICommand OpenActivateOnLaunchCommand { get; set; }
 
     #endregion
 
@@ -562,6 +568,24 @@ public class SettingsViewModel : BaseViewModel
     {
         _hotkeyManager.ClearAll();
         LoadHotkeyDisplays();
+    }
+
+    private void OpenActivateOnLaunch()
+    {
+        if (_activateOnLaunchWindow != null && _activateOnLaunchWindow.IsVisible)
+        {
+            _activateOnLaunchWindow.Activate();
+            return;
+        }
+
+        _activateOnLaunchWindow = new ActivateOnLaunchWindow(_activateOnLaunchViewModel)
+        {
+            DataContext = _activateOnLaunchViewModel,
+            Owner = Application.Current.MainWindow
+        };
+
+        _activateOnLaunchWindow.Closed += (_, _) => _activateOnLaunchWindow = null;
+        _activateOnLaunchWindow.ShowDialog();
     }
 
     #endregion

--- a/SekiroTool/Views/Tabs/SettingsTab.xaml
+++ b/SekiroTool/Views/Tabs/SettingsTab.xaml
@@ -112,6 +112,28 @@
                               IsChecked="{Binding IsDisableMenuMusicEnabled}"
                               Margin="25,0,0,0" />
                 </StackPanel>
+
+                <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                    <Button Content="Activate On Launch"
+                            Command="{Binding OpenActivateOnLaunchCommand}"
+                            Padding="6,2" />
+                    <Border
+                        Background="#3498db"
+                        CornerRadius="10"
+                        Width="12"
+                        Height="12"
+                        Margin="5,0,0,0"
+                        VerticalAlignment="Center"
+                        ToolTip="Choose options to automatically activate on game/SekiroTool load or on every New Game"
+                        ToolTipService.InitialShowDelay='100'>
+                        <TextBlock Text="i"
+                                   Foreground="White"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   FontWeight="Bold"
+                                   FontSize="10" />
+                    </Border>
+                </StackPanel>
             </StackPanel>
 
             <Separator Margin="0,0,0,10" />

--- a/SekiroTool/Views/Tabs/SettingsTab.xaml
+++ b/SekiroTool/Views/Tabs/SettingsTab.xaml
@@ -73,6 +73,25 @@
                     <CheckBox Content="Disable Cutscenes"
                               IsChecked="{Binding IsNoCutsceneEnabled}"
                               Margin="0,0,10,0" />
+                    <Button Content="Activate On Launch"
+                            Command="{Binding OpenActivateOnLaunchCommand}"
+                            Padding="6,2" />
+                    <Border
+                        Background="#3498db"
+                        CornerRadius="10"
+                        Width="12"
+                        Height="12"
+                        Margin="5,0,0,0"
+                        VerticalAlignment="Center"
+                        ToolTip="Choose options to automatically activate on game/SekiroTool load or on every New Game"
+                        ToolTipService.InitialShowDelay='100'>
+                        <TextBlock Text="i"
+                                   Foreground="White"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   FontWeight="Bold"
+                                   FontSize="10" />
+                    </Border>
                 </StackPanel>
 
                 <StackPanel
@@ -111,28 +130,6 @@
                     <CheckBox Content="Disable Menu Music"
                               IsChecked="{Binding IsDisableMenuMusicEnabled}"
                               Margin="25,0,0,0" />
-                </StackPanel>
-
-                <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                    <Button Content="Activate On Launch"
-                            Command="{Binding OpenActivateOnLaunchCommand}"
-                            Padding="6,2" />
-                    <Border
-                        Background="#3498db"
-                        CornerRadius="10"
-                        Width="12"
-                        Height="12"
-                        Margin="5,0,0,0"
-                        VerticalAlignment="Center"
-                        ToolTip="Choose options to automatically activate on game/SekiroTool load or on every New Game"
-                        ToolTipService.InitialShowDelay='100'>
-                        <TextBlock Text="i"
-                                   Foreground="White"
-                                   HorizontalAlignment="Center"
-                                   VerticalAlignment="Center"
-                                   FontWeight="Bold"
-                                   FontSize="10" />
-                    </Border>
                 </StackPanel>
             </StackPanel>
 

--- a/SekiroTool/Views/Tabs/SettingsTab.xaml.cs
+++ b/SekiroTool/Views/Tabs/SettingsTab.xaml.cs
@@ -8,14 +8,14 @@ namespace SekiroTool.Views.Tabs;
 public partial class SettingsTab : UserControl
 {
     private readonly SettingsViewModel _settingsViewModel;
-        
+
     public SettingsTab(SettingsViewModel settingsViewModel)
     {
         DataContext = settingsViewModel;
         _settingsViewModel = settingsViewModel;
         InitializeComponent();
     }
-    
+
     private void UserControl_Loaded(object sender, RoutedEventArgs e)
     {
         Dispatcher.BeginInvoke(new Action(() =>

--- a/SekiroTool/Views/Windows/ActivateOnLaunchWindow.xaml
+++ b/SekiroTool/Views/Windows/ActivateOnLaunchWindow.xaml
@@ -1,0 +1,186 @@
+<Window x:Class="SekiroTool.Views.Windows.ActivateOnLaunchWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+        mc:Ignorable="d"
+        Title="Activate On Launch"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Width="460"
+        Height="620"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent">
+
+    <Window.Resources>
+        <Style x:Key="SectionHeaderStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="Foreground" Value="{StaticResource AccentBrush}" />
+            <Setter Property="Margin" Value="0,0,0,6" />
+        </Style>
+
+        <Style x:Key="InfoBubbleStyle" TargetType="Border">
+            <Setter Property="Background" Value="#3498db" />
+            <Setter Property="CornerRadius" Value="10" />
+            <Setter Property="Width" Value="12" />
+            <Setter Property="Height" Value="12" />
+            <Setter Property="Margin" Value="5,-3,0,0" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="ToolTipService.InitialShowDelay" Value="100" />
+        </Style>
+
+        <Style x:Key="InfoBubbleTextStyle" TargetType="TextBlock">
+            <Setter Property="Text" Value="i" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="FontSize" Value="10" />
+        </Style>
+    </Window.Resources>
+
+    <Border Background="{StaticResource BackgroundBrush}" Margin="10">
+        <Border.Effect>
+            <DropShadowEffect BlurRadius="10" ShadowDepth="0" Opacity="0.5" />
+        </Border.Effect>
+
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="30" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <Border Grid.Row="0"
+                    Background="{StaticResource TitleBarBrush}"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Text="Activate On Launch"
+                               Grid.Column="0"
+                               Foreground="White"
+                               FontWeight="SemiBold"
+                               VerticalAlignment="Center"
+                               Margin="10,0,0,0" />
+
+                    <Button Content="✕"
+                            Grid.Column="1"
+                            Width="30"
+                            Height="30"
+                            Click="CloseButton_Click">
+                        <Button.Style>
+                            <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                                <Setter Property="Background" Value="Transparent" />
+                                <Setter Property="BorderThickness" Value="0" />
+                                <Style.Triggers>
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter Property="Background" Value="#E81123" />
+                                        <Setter Property="Foreground" Value="White" />
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                    </Button>
+                </Grid>
+            </Border>
+
+            <Grid Grid.Row="1" Margin="15">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <CheckBox Grid.Row="0"
+                          Content="Enable Activate On Launch"
+                          IsChecked="{Binding IsEnabled}"
+                          FontWeight="SemiBold"
+                          Margin="0,0,0,10"
+                          ToolTip="When disabled, your selected options below are still saved but won't be activated on launch or New Game."
+                          ToolTipService.InitialShowDelay="100" />
+
+                <Border Grid.Row="1" BorderThickness="1" BorderBrush="#333" CornerRadius="3">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                        <StackPanel Margin="10">
+
+                            <!-- Player -->
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Player" Style="{StaticResource SectionHeaderStyle}" />
+                                <Border Style="{StaticResource InfoBubbleStyle}"
+                                        ToolTip="Features in this section activate as soon as the tool loads into the game.">
+                                    <TextBlock Style="{StaticResource InfoBubbleTextStyle}" />
+                                </Border>
+                            </StackPanel>
+                            <CheckBox Content="Infinite Confetti" Margin="0,0,0,4" IsChecked="{Binding IsInfiniteConfettiChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="Infinite Gachiin" Margin="0,0,0,4" IsChecked="{Binding IsInfiniteGachiinChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="One Shot Health" Margin="0,0,0,4" IsChecked="{Binding IsOneShotHealthChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="One Shot Posture" Margin="0,0,0,4" IsChecked="{Binding IsOneShotPostureChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="No Goods Consume" Margin="0,0,0,4" IsChecked="{Binding IsNoGoodsConsumeChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="No Emblem Consume" Margin="0,0,0,4" IsChecked="{Binding IsNoEmblemConsumeChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="Infinite Revival" Margin="0,0,0,4" IsChecked="{Binding IsInfiniteRevivalChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="Player Hide" Margin="0,0,0,4" IsChecked="{Binding IsPlayerHideChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="Player Silent" Margin="0,0,0,4" IsChecked="{Binding IsPlayerSilentChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="Infinite Poise" Margin="0,0,0,4" IsChecked="{Binding IsInfinitePoiseChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="No Death" Margin="0,0,0,4" IsChecked="{Binding IsNoDeathChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="No Death (Yes Killbox)" Margin="0,0,0,4" IsChecked="{Binding IsNoDeathExKillboxChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="No Damage" Margin="0,0,0,4" IsChecked="{Binding IsNoDamageChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                                <CheckBox Content="Damage Multiplier:" IsChecked="{Binding IsToggleDamageMultiplierChecked}" IsEnabled="{Binding IsEnabled}" VerticalAlignment="Center" />
+                                <xctk:DoubleUpDown Margin="8,0,0,0"
+                                                    Width="90"
+                                                    Value="{Binding DamageMultiplierValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                    Minimum="0"
+                                                    Maximum="100"
+                                                    Increment="0.1"
+                                                    FormatString="F1"
+                                                    TextAlignment="Center"
+                                                    IsEnabled="{Binding IsEnabled}"
+                                                    BorderBrush="#3F3F46" />
+                            </StackPanel>
+
+                            <!-- Target -->
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Target" Style="{StaticResource SectionHeaderStyle}" Margin="0,14,0,6" />
+                                <Border Style="{StaticResource InfoBubbleStyle}" Margin="5,10,0,0"
+                                        ToolTip="Features in this section activate as soon as the tool loads into the game.">
+                                    <TextBlock Style="{StaticResource InfoBubbleTextStyle}" />
+                                </Border>
+                            </StackPanel>
+                            <CheckBox Content="Enable Target Options" Margin="0,0,0,4" IsChecked="{Binding IsEnableTargetOptionsChecked}" IsEnabled="{Binding IsEnabled}" />
+
+                            <!-- Travel -->
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Travel" Style="{StaticResource SectionHeaderStyle}" Margin="0,14,0,6" />
+                                <Border Style="{StaticResource InfoBubbleStyle}" Margin="5,10,0,0"
+                                        ToolTip="Features in this section activate when a fresh New Game is detected.">
+                                    <TextBlock Style="{StaticResource InfoBubbleTextStyle}" />
+                                </Border>
+                            </StackPanel>
+                            <CheckBox Content="Unlock All Idols" Margin="0,0,0,4" IsChecked="{Binding IsUnlockIdolsChecked}" IsEnabled="{Binding IsEnabled}" />
+
+                            <!-- New Game Cycle -->
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="New Game Cycle" Style="{StaticResource SectionHeaderStyle}" Margin="0,14,0,6" />
+                                <Border Style="{StaticResource InfoBubbleStyle}" Margin="5,10,0,0"
+                                        ToolTip="Features in this section activate when a fresh New Game is detected.">
+                                    <TextBlock Style="{StaticResource InfoBubbleTextStyle}" />
+                                </Border>
+                            </StackPanel>
+                            <CheckBox Content="Auto Set NG+7" Margin="0,0,0,4" IsChecked="{Binding IsAutoSetNewGame7Checked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="Demon Bell On" Margin="0,0,0,4" IsChecked="{Binding IsDemonBellOnChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="Demon Bell Off" Margin="0,0,0,4" IsChecked="{Binding IsDemonBellOffChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="No Kuro's Charm On" Margin="0,0,0,4" IsChecked="{Binding IsNoKurosCharmOnChecked}" IsEnabled="{Binding IsEnabled}" />
+                            <CheckBox Content="No Kuro's Charm Off" Margin="0,0,0,4" IsChecked="{Binding IsNoKurosCharmOffChecked}" IsEnabled="{Binding IsEnabled}" />
+
+                        </StackPanel>
+                    </ScrollViewer>
+                </Border>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/SekiroTool/Views/Windows/ActivateOnLaunchWindow.xaml.cs
+++ b/SekiroTool/Views/Windows/ActivateOnLaunchWindow.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+using System.Windows.Input;
+using SekiroTool.ViewModels;
+
+namespace SekiroTool.Views.Windows;
+
+public partial class ActivateOnLaunchWindow : Window
+{
+    public ActivateOnLaunchWindow(ActivateOnLaunchViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel;
+    }
+
+    private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e) => DragMove();
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+}


### PR DESCRIPTION
It follows the same architecture as TarnishedTool. I tested all options and they appear to work as expected.

I also added _Enable target options_ as an activable on launch feature (it it activated when the game is loaded, not when the tool is attached), as well as DB/NKC event flags (because I am lazy and do not like going to the bell to ring it on each practice run). 

Finally, a small fix for _No Emblem Consume_. 


<img width="460" height="620" alt="SekiroTool_SZYq5tSP10" src="https://github.com/user-attachments/assets/224fc3d9-4c15-44cb-a31a-3f4cc72bbe07" />

