### PR TITLE
(feat): add target health and posture percentages

### DIFF
--- a/SekiroTool/ViewModels/TargetViewModel.cs
+++ b/SekiroTool/ViewModels/TargetViewModel.cs
@@ -170,14 +170,26 @@ public class TargetViewModel : BaseViewModel
     public int TargetCurrentHealth
     {
         get => _targetCurrentHealth;
-        set => SetProperty(ref _targetCurrentHealth, value);
+        set
+        {
+            SetProperty(ref _targetCurrentHealth, value);
+            OnPropertyChanged(nameof(TargetHealthPercentage));
+        }
     }
 
     public int TargetMaxHealth
     {
         get => _targetMaxHealth;
-        set => SetProperty(ref _targetMaxHealth, value);
+        set
+        {
+            SetProperty(ref _targetMaxHealth, value);
+            OnPropertyChanged(nameof(TargetHealthPercentage));
+        }
     }
+    
+    public string TargetHealthPercentage => TargetMaxHealth > 0
+        ? (TargetCurrentHealth / (double)TargetMaxHealth * 100).ToString("F1")
+        : "0.0";
 
     public bool IsFreezeHealthEnabled
     {
@@ -204,14 +216,26 @@ public class TargetViewModel : BaseViewModel
     public int TargetCurrentPosture
     {
         get => _targetCurrentPosture;
-        set => SetProperty(ref _targetCurrentPosture, value);
+        set
+        {
+            SetProperty(ref _targetCurrentPosture, value);
+            OnPropertyChanged(nameof(TargetPosturePercentage));
+        }
     }
 
     public int TargetMaxPosture
     {
         get => _targetMaxPosture;
-        set => SetProperty(ref _targetMaxPosture, value);
+        set
+        {
+            SetProperty(ref _targetMaxPosture, value);
+            OnPropertyChanged(nameof(TargetPosturePercentage));
+        }
     }
+    
+    public string TargetPosturePercentage => TargetMaxPosture > 0
+        ? (TargetCurrentPosture / (double)TargetMaxPosture * 100).ToString("F1")
+        : "0.0";
 
     public bool IsFreezePostureEnabled
     {

--- a/SekiroTool/Views/Tabs/TargetTab.xaml
+++ b/SekiroTool/Views/Tabs/TargetTab.xaml
@@ -40,8 +40,9 @@
                             <Run Text="{Binding TargetCurrentHealth, Mode=OneWay}" />
                             <Run Text="/" />
                             <Run Text="{Binding TargetMaxHealth, Mode=OneWay}" />
+                            <Run Text="{Binding TargetHealthPercentage, Mode=OneWay, StringFormat={}({0}%)}" />
                         </TextBlock>
-
+                        
                         <xctk:IntegerUpDown Width="80" Margin="5,2"
                                             HorizontalAlignment="Right"
                                             Value="{Binding CustomHp}"
@@ -158,6 +159,7 @@
                             <Run Text="{Binding TargetCurrentPosture, Mode=OneWay}" />
                             <Run Text="/" />
                             <Run Text="{Binding TargetMaxPosture, Mode=OneWay}" />
+                            <Run Text="{Binding TargetPosturePercentage, Mode=OneWay, StringFormat={}({0}%)}" />
                         </TextBlock>
                         <xctk:IntegerUpDown Width="80" Margin="5,2"
                                             HorizontalAlignment="Right"


### PR DESCRIPTION
Looked up how it's done in TarnishedTool and added here.

<img width="1400" height="632" alt="image" src="https://github.com/user-attachments/assets/0e12039e-92c1-4fc7-ab64-55c55a80b02e" />

I talked about it with centz a few months ago: it's usually more informative to know health/posture percentages rather than their exact values because Fromsoft usually ties logic with percentages, e.g."below 75.0% posture Genichiro can do quadra arrows". 